### PR TITLE
Adjust github workflow to call Makefile, and add a sleep to shutdown

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,14 +24,8 @@ jobs:
     - name: Display Go version
       run: go version
     
-    - name: Install dependencies
-      run: go get .
-
     - name: Build
-      run: go build -v ./...
+      run: make build
 
     - name: Smoketest
-      run: go run main.go --help
-
-    - name: Test
-      run: go test -v ./...
+      run: ./llm_proxy --help

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: Makefile
 
 ## build: build a binary
 .PHONY: build
-build: test
+build: test vet
 	go build -o ./llm_proxy -v
 
 ## vet: vet code

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,9 +13,9 @@ import (
 	px "github.com/kardianos/mitmproxy/proxy"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/proxati/llm_proxy/config"
 	"github.com/proxati/llm_proxy/proxy/addons"
 	md "github.com/proxati/llm_proxy/proxy/addons/megadumper"
-	"github.com/proxati/llm_proxy/config"
 )
 
 func newCA(certDir string) (*cert.CA, error) {
@@ -181,6 +181,9 @@ func startProxy(p *px.Proxy, shutdown chan os.Signal) error {
 		}
 		// Close the http client/server connections first
 		log.Debug("Closing proxy server...")
+
+		// Manual sleep to avoid race condition on connection close
+		time.Sleep(1 * time.Second)
 
 		// Create a context that will be cancelled after N seconds
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(60*time.Second))


### PR DESCRIPTION
Tests for race conditions are flaky because the server is closed while network connections are still open. Also, switch to use `make build` for running the tests.