### PR TITLE
switch to a single metaAddon, internal abstraction layer

### DIFF
--- a/proxy/metaAddon.go
+++ b/proxy/metaAddon.go
@@ -1,0 +1,139 @@
+package proxy
+
+import (
+	"io"
+
+	px "github.com/kardianos/mitmproxy/proxy"
+	"github.com/proxati/llm_proxy/config"
+)
+
+// metaAddon is a meta addon that is the only addon loaded by the upstream library, and all
+// of our internal addons are processed here. This is the first step of an abstraction layer,
+// so the upstream library can be replaced with a different one in the future.
+type metaAddon struct {
+	px.BaseAddon
+	cfg      *config.Config
+	myAddons []px.Addon
+}
+
+// NewMetaAddon creates a new MetaAddon with the given config and addons. The order of the addons
+// is important, as they will be processed in the order they are given. The first addon to return
+// with a response will be the final addon to process the request. Logging will be handled in a
+// separate system, and not in the addons (so the response can be captured).
+func newMetaAddon(cfg *config.Config, addons ...px.Addon) *metaAddon {
+	return &metaAddon{
+		cfg:      cfg,
+		myAddons: addons,
+	}
+}
+
+func (addon *metaAddon) addAddon(a px.Addon) {
+	addon.myAddons = append(addon.myAddons, a)
+}
+
+func (addon *metaAddon) ClientConnected(client *px.ClientConn) {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for client mutations, so just iterate peacefully
+		a.ClientConnected(client)
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) ClientDisconnected(client *px.ClientConn) {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for client mutations, so just iterate peacefully
+		a.ClientDisconnected(client)
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) ServerConnected(ctx *px.ConnContext) {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for context mutations, so just iterate peacefully
+		a.ServerConnected(ctx)
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) ServerDisconnected(ctx *px.ConnContext) {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for context mutations, so just iterate peacefully
+		a.ServerDisconnected(ctx)
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) TlsEstablishedServer(ctx *px.ConnContext) {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for context mutations, so just iterate peacefully
+		a.TlsEstablishedServer(ctx)
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) Requestheaders(flow *px.Flow) {
+	for _, a := range addon.myAddons {
+		a.Requestheaders(flow)
+		if flow.Response != nil {
+			// the response has been set, stop processing addons
+			break
+		}
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) Request(flow *px.Flow) {
+	for _, a := range addon.myAddons {
+		a.Request(flow)
+		if flow.Response != nil {
+			// the response has been set, stop processing addons
+			break
+		}
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) Responseheaders(flow *px.Flow) {
+	for _, a := range addon.myAddons {
+		a.Responseheaders(flow)
+
+		if flow.Response != nil && flow.Response.Body != nil {
+			// the response body has been set, stop processing addons
+			break
+		}
+	}
+
+	// TODO: add a logger here
+}
+
+func (addon *metaAddon) Response(flow *px.Flow) {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for flow mutations, so just iterate peacefully
+		a.Response(flow)
+	}
+
+	// TODO: add a logger here
+}
+func (addon *metaAddon) StreamRequestModifier(flow *px.Flow, in io.Reader) io.Reader {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for flow mutations, so just iterate peacefully
+		in = a.StreamRequestModifier(flow, in)
+	}
+
+	return in
+}
+func (addon *metaAddon) StreamResponseModifier(flow *px.Flow, in io.Reader) io.Reader {
+	for _, a := range addon.myAddons {
+		// the caller for this method doesn't check for flow mutations, so just iterate peacefully
+		in = a.StreamResponseModifier(flow, in)
+	}
+
+	return in
+}

--- a/proxy/metaAddon_test.go
+++ b/proxy/metaAddon_test.go
@@ -1,0 +1,133 @@
+package proxy
+
+import (
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	px "github.com/kardianos/mitmproxy/proxy"
+	"github.com/proxati/llm_proxy/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAddon implements the px.Addon interface for testing purposes.
+type mockAddon struct {
+	px.Addon
+	clientConnectedCalled        atomic.Bool
+	clientDisconnectedCalled     atomic.Bool
+	serverConnectedCalled        atomic.Bool
+	serverDisconnectedCalled     atomic.Bool
+	tlsEstablishedServerCalled   atomic.Bool
+	requestHeadersCalled         atomic.Bool
+	requestCalled                atomic.Bool
+	responseHeadersCalled        atomic.Bool
+	responseCalled               atomic.Bool
+	streamRequestModifierCalled  atomic.Bool
+	streamResponseModifierCalled atomic.Bool
+}
+
+func (m *mockAddon) ClientConnected(client *px.ClientConn) {
+	m.clientConnectedCalled.Store(true)
+}
+func (m *mockAddon) ClientDisconnected(client *px.ClientConn) {
+	m.clientDisconnectedCalled.Store(true)
+}
+func (m *mockAddon) ServerConnected(ctx *px.ConnContext) {
+	m.serverConnectedCalled.Store(true)
+}
+func (m *mockAddon) ServerDisconnected(ctx *px.ConnContext) {
+	m.serverDisconnectedCalled.Store(true)
+}
+func (m *mockAddon) TlsEstablishedServer(ctx *px.ConnContext) {
+	m.tlsEstablishedServerCalled.Store(true)
+}
+func (m *mockAddon) Requestheaders(f *px.Flow) {
+	m.requestHeadersCalled.Store(true)
+}
+func (m *mockAddon) Request(f *px.Flow) {
+	m.requestCalled.Store(true)
+}
+func (m *mockAddon) Responseheaders(f *px.Flow) {
+	m.responseHeadersCalled.Store(true)
+}
+func (m *mockAddon) Response(f *px.Flow) {
+	m.responseCalled.Store(true)
+}
+func (m *mockAddon) StreamRequestModifier(f *px.Flow, in io.Reader) io.Reader {
+	m.streamRequestModifierCalled.Store(true)
+	return in
+}
+func (m *mockAddon) StreamResponseModifier(f *px.Flow, in io.Reader) io.Reader {
+	m.streamResponseModifierCalled.Store(true)
+	return in
+}
+
+func TestNewMetaAddon(t *testing.T) {
+	cfg := &config.Config{}
+	addons := []px.Addon{&mockAddon{}, &mockAddon{}}
+
+	meta := newMetaAddon(cfg, addons...)
+	assert.Equal(t, cfg, meta.cfg)
+	assert.Equal(t, len(addons), len(meta.myAddons))
+}
+
+func TestAddAddon(t *testing.T) {
+	meta := newMetaAddon(&config.Config{})
+	mock := &mockAddon{}
+	meta.addAddon(mock)
+
+	assert.Contains(t, meta.myAddons, mock)
+}
+
+func TestAllMethods(t *testing.T) {
+	// create a proxy with a test config
+	proxyPort, err := getFreePort()
+	require.NoError(t, err)
+	tmpDir := t.TempDir()
+
+	// setup the metaAddon
+	meta := newMetaAddon(&config.Config{})
+	mock := &mockAddon{}
+	meta.addAddon(mock)
+
+	proxyShutdown, err := runProxy(proxyPort, tmpDir, config.SimpleMode, meta)
+	require.NoError(t, err)
+
+	// Start a basic web server on another port
+	hitCounter := new(atomic.Int32)
+	testServerPort, err := getFreePort()
+	require.NoError(t, err)
+	srv, srvShutdown := runWebServer(hitCounter, testServerPort)
+	require.NotNil(t, srv)
+	require.NotNil(t, srvShutdown)
+
+	// Create an http client that will use the proxy to connect to the web server
+	client, err := httpClient("http://" + proxyPort)
+	require.NoError(t, err)
+
+	t.Run("TestAddonMethodsCalled", func(t *testing.T) {
+		resp, err := client.Post("http://"+testServerPort, "text/plain", strings.NewReader("hello"))
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		assert.True(t, mock.clientConnectedCalled.Load())
+		assert.False(t, mock.clientDisconnectedCalled.Load())
+		assert.True(t, mock.serverConnectedCalled.Load())
+		assert.False(t, mock.serverDisconnectedCalled.Load())
+		assert.False(t, mock.tlsEstablishedServerCalled.Load())
+		assert.True(t, mock.requestHeadersCalled.Load())
+		assert.True(t, mock.requestCalled.Load())
+		assert.True(t, mock.responseHeadersCalled.Load())
+		assert.True(t, mock.responseCalled.Load())
+		assert.True(t, mock.streamRequestModifierCalled.Load())
+		assert.True(t, mock.streamResponseModifierCalled.Load())
+	})
+
+	// done with tests, send shutdown signals
+	t.Cleanup(func() {
+		srvShutdown()
+		proxyShutdown()
+	})
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	px "github.com/kardianos/mitmproxy/proxy"
 	"github.com/proxati/llm_proxy/config"
 	"github.com/proxati/llm_proxy/proxy/addons"
 	"github.com/proxati/llm_proxy/schema"
@@ -115,7 +116,7 @@ func runWebServer(hitCounter *atomic.Int32, listenAddr string) (*http.Server, fu
 	}
 }
 
-func runProxy(proxyPort, tempDir string, proxyAppMode config.AppMode) (shutdownFunc func(), err error) {
+func runProxy(proxyPort, tempDir string, proxyAppMode config.AppMode, addons ...px.Addon) (shutdownFunc func(), err error) {
 	// Create a simple proxy config
 	cfg := config.NewDefaultConfig()
 	cfg.Listen = proxyPort
@@ -130,6 +131,11 @@ func runProxy(proxyPort, tempDir string, proxyAppMode config.AppMode) (shutdownF
 	p, err := configProxy(cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	// add any additional addons
+	for _, addon := range addons {
+		p.AddAddon(addon)
 	}
 
 	// setup external control of the proxy


### PR DESCRIPTION
This change enables future logging improvements.

Since logs need to happen before and after all addons are processed, we need to have more control over when the addons are done. 