### PR TITLE
skip loading the logger addon when running in quiet mode

### DIFF
--- a/proxy/metaAddon_test.go
+++ b/proxy/metaAddon_test.go
@@ -6,8 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	px "github.com/proxati/mitmproxy/proxy"
 	"github.com/proxati/llm_proxy/config"
+	px "github.com/proxati/mitmproxy/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,7 +70,7 @@ func TestNewMetaAddon(t *testing.T) {
 
 	meta := newMetaAddon(cfg, addons...)
 	assert.Equal(t, cfg, meta.cfg)
-	assert.Equal(t, len(addons), len(meta.myAddons))
+	assert.Equal(t, len(addons), len(meta.mitmAddons))
 }
 
 func TestAddAddon(t *testing.T) {
@@ -78,7 +78,7 @@ func TestAddAddon(t *testing.T) {
 	mock := &mockAddon{}
 	meta.addAddon(mock)
 
-	assert.Contains(t, meta.myAddons, mock)
+	assert.Contains(t, meta.mitmAddons, mock)
 }
 
 func TestAllMethods(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -79,19 +79,21 @@ func configProxy(cfg *config.Config) (*px.Proxy, error) {
 	// struct of bools to toggle the various traffic log outputs
 	logSources := config.NewLogSourceConfig(cfg)
 
-	// create and configure MegaDirDumper addon object
-	dumperAddon, err := addons.NewMegaDumpAddon(
-		cfg.OutputDir,
-		cfg.LogFormat,
-		logSources,
-		cfg.FilterReqHeaders, cfg.FilterRespHeaders,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create traffic log dumper: %v", err)
-	}
+	// create and configure MegaDirDumper addon object, but bypass traffic logs when no output is requeste
+	if (cfg.OutputDir == "" && cfg.IsVerboseOrHigher()) || cfg.OutputDir != "" {
+		dumperAddon, err := addons.NewMegaDumpAddon(
+			cfg.OutputDir,
+			cfg.LogFormat,
+			logSources,
+			cfg.FilterReqHeaders, cfg.FilterRespHeaders,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create traffic log dumper: %v", err)
+		}
 
-	// add the traffic log dumper to the proxy
-	metaAdd.addAddon(dumperAddon)
+		// add the traffic log dumper to the proxy
+		metaAdd.addAddon(dumperAddon)
+	}
 
 	log.Debugf("AppMode set to: %v", cfg.AppMode)
 	switch cfg.AppMode {


### PR DESCRIPTION
This change also setups a type assertion when loading addons into the metaAddon, so we can start to decouple the addon types from what the mitmproxy library requires.