### PR TITLE
relocate toProxyResponse out of the base schema package

### DIFF
--- a/proxy/addons/responseCache.go
+++ b/proxy/addons/responseCache.go
@@ -91,7 +91,7 @@ func (c *ResponseCacheAddon) Request(f *px.Flow) {
 	// handle cache hit
 	logger.Info("cache hit")
 
-	cachedResp, err := cacheLookup.ToProxyResponse(f.Request.Header.Get("Accept-Encoding"))
+	cachedResp, err := mitm.ToProxyResponse(cacheLookup, f.Request.Header.Get("Accept-Encoding"))
 	if err != nil {
 		logger.Error("error converting cached response to ProxyResponse", "error", err)
 		return

--- a/proxy/addons/responseCache_test.go
+++ b/proxy/addons/responseCache_test.go
@@ -225,8 +225,8 @@ func TestRequest(t *testing.T) {
 			},
 		}
 		// compress the body to simulate a real response
-		respString := "resp2"
-		encodedBody, _, err := utils.EncodeBody(&respString, "gzip")
+		respBytes := []byte("resp2")
+		encodedBody, _, err := utils.EncodeBody(respBytes, "gzip")
 		require.NoError(t, err)
 		resp.Body = encodedBody
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -148,8 +148,8 @@ func runWebServer(hitCounter *atomic.Int32, listenAddr string) (*http.Server, fu
 		// increment the counter
 		hitCounter.Add(1)
 
-		resp := string(respBuilder(hitCounter.Load(), r.Body))
-		encodedResp, encoding, err := utils.EncodeBody(&resp, r.Header.Get("Accept-Encoding"))
+		resp := respBuilder(hitCounter.Load(), r.Body)
+		encodedResp, encoding, err := utils.EncodeBody(resp, r.Header.Get("Accept-Encoding"))
 		if err != nil {
 			log.Printf("error encoding response: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/schema/proxyAdapters/mitm/responseAdapter.go
+++ b/schema/proxyAdapters/mitm/responseAdapter.go
@@ -29,29 +29,3 @@ func (r *ProxyResponseAdapter) GetHeaders() http.Header {
 func (r *ProxyResponseAdapter) GetBodyBytes() []byte {
 	return r.pxResp.Body
 }
-
-/*
-// ToProxyResponse converts a ProxyResponse into a MITM proxy response object (with content encoding matching the new req)
-// Because all responses are stored as uncompressed strings, the cached response might need to be encoded before being sent
-// TODO: move this out of the base schema package!
-func (pRes *ProxyResponse) ToProxyResponse(acceptEncodingHeader string) (*px.Response, error) {
-	resp := &px.Response{
-		StatusCode: pRes.Status,
-		Header:     pRes.Header,
-	}
-
-	// encode the body based on the new request's accept encoding header
-	encodedBody, encoding, err := utils.EncodeBody(&pRes.Body, acceptEncodingHeader)
-	if err != nil {
-		return nil, fmt.Errorf("error encoding body: %v", err)
-	}
-
-	// set the new content encoding and length headers
-	resp.Header.Set("Content-Encoding", encoding)
-	resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(encodedBody)))
-
-	resp.Body = encodedBody
-	return resp, nil
-}
-
-*/

--- a/schema/proxyAdapters/mitm/toProxyResponse.go
+++ b/schema/proxyAdapters/mitm/toProxyResponse.go
@@ -10,7 +10,6 @@ import (
 
 // ToProxyResponse converts a ProxyResponse into a MITM proxy response object (with content encoding matching the new req)
 // Because all responses are stored as uncompressed strings, the cached response might need to be encoded before being sent
-// TODO: move this out of the base schema package!
 func ToProxyResponse(pRes proxyAdapters.ResponseReaderAdapter, acceptEncodingHeader string) (*px.Response, error) {
 	resp := &px.Response{
 		StatusCode: pRes.GetStatusCode(),

--- a/schema/proxyAdapters/mitm/toProxyResponse.go
+++ b/schema/proxyAdapters/mitm/toProxyResponse.go
@@ -1,0 +1,33 @@
+package mitm
+
+import (
+	"fmt"
+
+	"github.com/proxati/llm_proxy/v2/schema/proxyAdapters"
+	"github.com/proxati/llm_proxy/v2/schema/utils"
+	px "github.com/proxati/mitmproxy/proxy"
+)
+
+// ToProxyResponse converts a ProxyResponse into a MITM proxy response object (with content encoding matching the new req)
+// Because all responses are stored as uncompressed strings, the cached response might need to be encoded before being sent
+// TODO: move this out of the base schema package!
+func ToProxyResponse(pRes proxyAdapters.ResponseReaderAdapter, acceptEncodingHeader string) (*px.Response, error) {
+	resp := &px.Response{
+		StatusCode: pRes.GetStatusCode(),
+		Header:     pRes.GetHeaders(),
+	}
+	body := pRes.GetBodyBytes()
+
+	// encode the body based on the new request's accept encoding header
+	encodedBody, encoding, err := utils.EncodeBody(body, acceptEncodingHeader)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding body: %v", err)
+	}
+
+	// set the new content encoding and length headers
+	resp.Header.Set("Content-Encoding", encoding)
+	resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(encodedBody)))
+
+	resp.Body = encodedBody
+	return resp, nil
+}

--- a/schema/proxyAdapters/mitm/toProxyResponse_test.go
+++ b/schema/proxyAdapters/mitm/toProxyResponse_test.go
@@ -1,0 +1,78 @@
+package mitm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/proxati/llm_proxy/v2/schema/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockResponseReaderAdapter is a mock implementation of the ResponseReaderAdapter interface
+type MockResponseReaderAdapter struct {
+	StatusCode int
+	Headers    http.Header
+	Body       []byte
+}
+
+func (m *MockResponseReaderAdapter) GetStatusCode() int {
+	return m.StatusCode
+}
+
+func (m *MockResponseReaderAdapter) GetHeaders() http.Header {
+	return m.Headers
+}
+
+func (m *MockResponseReaderAdapter) GetBodyBytes() []byte {
+	return m.Body
+}
+
+func TestToProxyResponse(t *testing.T) {
+	mockResponseReader := &MockResponseReaderAdapter{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"key":"value"}`),
+	}
+
+	t.Run("Successful conversion", func(t *testing.T) {
+		acceptEncodingHeader := "gzip"
+		encodedBody, encoding, err := utils.EncodeBody(
+			mockResponseReader.GetBodyBytes(), acceptEncodingHeader)
+		require.NoError(t, err)
+
+		resp, err := ToProxyResponse(mockResponseReader, acceptEncodingHeader)
+		require.NoError(t, err)
+		assert.Equal(t, mockResponseReader.GetStatusCode(), resp.StatusCode)
+
+		// a few headers added by the encoding process
+		assert.Equal(t, http.Header{
+			"Content-Type":     {"application/json"},
+			"Content-Encoding": {encoding},
+			"Content-Length":   {fmt.Sprintf("%d", len(encodedBody))},
+		}, resp.Header)
+		assert.Equal(t, encodedBody, resp.Body)
+	})
+
+	t.Run("Invalid encoding means uncompressed response", func(t *testing.T) {
+		acceptEncodingHeader := "invalid-encoding"
+		encodedBody, encoding, err := utils.EncodeBody(
+			mockResponseReader.GetBodyBytes(), acceptEncodingHeader)
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"key":"value"}`), encodedBody)
+		assert.Equal(t, "", encoding)
+
+		resp, err := ToProxyResponse(mockResponseReader, acceptEncodingHeader)
+		require.NoError(t, err)
+		assert.Equal(t, mockResponseReader.GetStatusCode(), resp.StatusCode)
+
+		// a few headers added by the encoding process
+		assert.Equal(t, http.Header{
+			"Content-Type":     {"application/json"},
+			"Content-Encoding": {encoding},
+			"Content-Length":   {fmt.Sprintf("%d", len(encodedBody))},
+		}, resp.Header)
+		assert.Equal(t, encodedBody, resp.Body)
+	})
+}

--- a/schema/utils/EncodeBody.go
+++ b/schema/utils/EncodeBody.go
@@ -111,20 +111,19 @@ func brotliCompress(body []byte) ([]byte, string, error) {
 }
 
 // EncodeBody compresses a string (the response body) based on the content-encoding header
-func EncodeBody(body *string, acceptEncodingHeader string) (encodedBody []byte, encoding string, err error) {
+func EncodeBody(body []byte, acceptEncodingHeader string) (encodedBody []byte, encoding string, err error) {
 	selectedEncoding := chooseEncoding(&acceptEncodingHeader)
-	bodyBytes := []byte(*body)
 
 	switch selectedEncoding {
 	case gzipEncoding:
-		return gzipCompress(bodyBytes)
+		return gzipCompress(body)
 	case deflateEncoding:
-		return deflateCompress(bodyBytes)
+		return deflateCompress(body)
 	case brotliEncoding:
-		return brotliCompress(bodyBytes)
+		return brotliCompress(body)
 	case "", identityEncoding:
 		// default to empty encoding for the "identity" accept-encoding header
-		return bodyBytes, "", nil
+		return body, "", nil
 	}
 	return nil, "", fmt.Errorf("unsupported encoding: %s", selectedEncoding)
 }

--- a/schema/utils/EncodeBody.go
+++ b/schema/utils/EncodeBody.go
@@ -12,6 +12,8 @@ import (
 )
 
 // parseAcceptEncoding parses the Accept-Encoding header to find out what encodings are accepted.
+// no error management is done here, as the header encoding and quality is returned regardless of
+// the validity.
 func parseAcceptEncoding(headerValue *string) map[string]float64 {
 	encodings := make(map[string]float64)
 	if *headerValue == "" {
@@ -125,5 +127,5 @@ func EncodeBody(body []byte, acceptEncodingHeader string) (encodedBody []byte, e
 		// default to empty encoding for the "identity" accept-encoding header
 		return body, "", nil
 	}
-	return nil, "", fmt.Errorf("unsupported encoding: %s", selectedEncoding)
+	return nil, "", fmt.Errorf("could not determine encoding type: %s", selectedEncoding)
 }

--- a/schema/utils/EncodeBody_test.go
+++ b/schema/utils/EncodeBody_test.go
@@ -291,7 +291,7 @@ func TestEncodeBody(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		body                 string
+		body                 []byte
 		acceptEncodingHeader string
 		wantErr              bool
 		expectedOutput       []byte // nil when we expect an error
@@ -299,7 +299,7 @@ func TestEncodeBody(t *testing.T) {
 	}{
 		{
 			name:                 "Encode with gzip",
-			body:                 bodyText,
+			body:                 []byte(bodyText),
 			acceptEncodingHeader: "gzip",
 			wantErr:              false,
 			expectedOutput:       []byte(bodyText),
@@ -307,7 +307,7 @@ func TestEncodeBody(t *testing.T) {
 		},
 		{
 			name:                 "Encode with deflate",
-			body:                 bodyText,
+			body:                 []byte(bodyText),
 			acceptEncodingHeader: "deflate",
 			wantErr:              false,
 			expectedOutput:       []byte(bodyText),
@@ -315,7 +315,7 @@ func TestEncodeBody(t *testing.T) {
 		},
 		{
 			name:                 "No encoding",
-			body:                 bodyText,
+			body:                 []byte(bodyText),
 			acceptEncodingHeader: "",
 			wantErr:              false,
 			expectedOutput:       []byte(bodyText),
@@ -323,7 +323,7 @@ func TestEncodeBody(t *testing.T) {
 		},
 		{
 			name:                 "identity encoding",
-			body:                 bodyText,
+			body:                 []byte(bodyText),
 			acceptEncodingHeader: "identity",
 			wantErr:              false,
 			expectedOutput:       []byte(bodyText),
@@ -331,7 +331,7 @@ func TestEncodeBody(t *testing.T) {
 		},
 		{
 			name:                 "Brotli encoding",
-			body:                 bodyText,
+			body:                 []byte(bodyText),
 			acceptEncodingHeader: "br",
 			wantErr:              false,
 			expectedOutput:       []byte(bodyText),
@@ -339,7 +339,7 @@ func TestEncodeBody(t *testing.T) {
 		},
 		{
 			name:                 "Empty body with gzip",
-			body:                 "",
+			body:                 []byte(""),
 			acceptEncodingHeader: "gzip",
 			wantErr:              false,
 			expectedOutput:       []byte(""),
@@ -347,7 +347,7 @@ func TestEncodeBody(t *testing.T) {
 		},
 		{
 			name:                 "Empty body with no encoding",
-			body:                 "",
+			body:                 []byte(""),
 			acceptEncodingHeader: "",
 			wantErr:              false,
 			expectedOutput:       []byte(""),
@@ -357,7 +357,7 @@ func TestEncodeBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output, encoding, err := EncodeBody(&tt.body, tt.acceptEncodingHeader)
+			output, encoding, err := EncodeBody(tt.body, tt.acceptEncodingHeader)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EncodeBody() test = %s output = %s encoding = %s error = %v, wantErr %v", tt.name, output, encoding, err, tt.wantErr)
 				return


### PR DESCRIPTION
this change completes the work to remove the mitm library from the base schema package