### PR TITLE
copy the log object upon write, and write to all destinations concurrently

### DIFF
--- a/proxy/addons/megadumper/logDestination.go
+++ b/proxy/addons/megadumper/logDestination.go
@@ -35,8 +35,8 @@ func (ld *LogDestination) String() string {
 // Write writes a log dump container object to it's log destination. The
 // formatter is responsible for converting the log dump container the correct
 // format (json, text, etc) before writing.
-func (ld *LogDestination) Write(identifier string, logDumpContainer *schema.LogDumpContainer) (int, error) {
-	bytes, err := ld.formatter.Read(logDumpContainer)
+func (ld *LogDestination) Write(identifier string, logDumpContainer schema.LogDumpContainer) (int, error) {
+	bytes, err := ld.formatter.Read(&logDumpContainer)
 	if err != nil {
 		return 0, fmt.Errorf("could not format log dump container: %w", err)
 	}

--- a/proxy/addons/megadumper/logDestination_test.go
+++ b/proxy/addons/megadumper/logDestination_test.go
@@ -121,7 +121,7 @@ func TestLogDestination_Write(t *testing.T) {
 
 	// Write LogDumpContainer
 	identifier := "test_identifier"
-	_, err = logDestination.Write(identifier, logDumpContainer)
+	_, err = logDestination.Write(identifier, *logDumpContainer)
 	require.NoError(t, err)
 
 	// Verify Output


### PR DESCRIPTION
This avoids a potential race condition with the log object by copying the full log object to the writer.